### PR TITLE
Bug 1755757: store: add kube_node_role metric

### DIFF
--- a/Documentation/node-metrics.md
+++ b/Documentation/node-metrics.md
@@ -4,6 +4,7 @@
 | ---------- | ----------- | ----------- | ----------- |
 | kube_node_info | Gauge | `node`=&lt;node-address&gt; <br> `kernel_version`=&lt;kernel-version&gt; <br> `os_image`=&lt;os-image-name&gt; <br> `container_runtime_version`=&lt;container-runtime-and-version-combination&gt; <br> `kubelet_version`=&lt;kubelet-version&gt; <br> `kubeproxy_version`=&lt;kubeproxy-version&gt; <br> `provider_id`=&lt;provider-id&gt; | STABLE |
 | kube_node_labels | Gauge | `node`=&lt;node-address&gt; <br> `label_NODE_LABEL`=&lt;NODE_LABEL&gt;  | STABLE |
+| kube_node_role | Gauge | `node`=&lt;node-address&gt; <br> `role`=&lt;NODE_ROLE&gt; | EXPERIMENTAL |
 | kube_node_spec_unschedulable | Gauge | `node`=&lt;node-address&gt;|
 | kube_node_spec_taint | Gauge | `node`=&lt;node-address&gt; <br> `key`=&lt;taint-key&gt; <br> `value=`&lt;taint-value&gt; <br> `effect=`&lt;taint-effect&gt; | STABLE |
 | kube_node_status_phase| Gauge | `node`=&lt;node-address&gt; <br> `phase`=&lt;Pending\|Running\|Terminated&gt; | STABLE |

--- a/pkg/collectors/node.go
+++ b/pkg/collectors/node.go
@@ -17,10 +17,12 @@ limitations under the License.
 package collectors
 
 import (
+	"strings"
+
 	"k8s.io/kube-state-metrics/pkg/constant"
 	"k8s.io/kube-state-metrics/pkg/metrics"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -91,6 +93,26 @@ var (
 					LabelValues: labelValues,
 					Value:       1,
 				}}
+			}),
+		},
+		metrics.FamilyGenerator{
+			Name: "kube_node_role",
+			Type: metrics.MetricTypeGauge,
+			Help: "The role of a cluster node.",
+			GenerateFunc: wrapNodeFunc(func(n *v1.Node) metrics.Family {
+				const prefix = "node-role.kubernetes.io/"
+				ms := metrics.Family{}
+				for lbl := range n.Labels {
+					if strings.HasPrefix(lbl, prefix) {
+						ms = append(ms, &metrics.Metric{
+							Name:        "kube_node_role",
+							LabelKeys:   []string{"role"},
+							LabelValues: []string{strings.TrimPrefix(lbl, prefix)},
+							Value:       float64(1),
+						})
+					}
+				}
+				return ms
 			}),
 		},
 		metrics.FamilyGenerator{

--- a/pkg/collectors/node_test.go
+++ b/pkg/collectors/node_test.go
@@ -93,7 +93,7 @@ func TestNodeCollector(t *testing.T) {
 					Name:              "127.0.0.1",
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 					Labels: map[string]string{
-						"type": "master",
+						"node-role.kubernetes.io/master": "",
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -127,9 +127,10 @@ func TestNodeCollector(t *testing.T) {
 				},
 			},
 			Want: `
-        kube_node_created{node="127.0.0.1"} 1.5e+09
+		kube_node_created{node="127.0.0.1"} 1.5e+09
         kube_node_info{container_runtime_version="rkt",kernel_version="kernel",kubelet_version="kubelet",kubeproxy_version="kubeproxy",node="127.0.0.1",os_image="osimage",provider_id="provider://i-randomidentifier"} 1
-        kube_node_labels{label_type="master",node="127.0.0.1"} 1
+		kube_node_labels{label_node_role_kubernetes_io_master="",node="127.0.0.1"} 1
+		kube_node_role{node="127.0.0.1",role="master"} 1
         kube_node_spec_unschedulable{node="127.0.0.1"} 1
         kube_node_status_allocatable_cpu_cores{node="127.0.0.1"} 3
         kube_node_status_allocatable_memory_bytes{node="127.0.0.1"} 1e+09
@@ -150,6 +151,21 @@ func TestNodeCollector(t *testing.T) {
         kube_node_status_capacity{node="127.0.0.1",resource="pods",unit="integer"} 1000
         kube_node_status_capacity{node="127.0.0.1",resource="storage",unit="byte"} 3e+09
 			`,
+			MetricNames: []string{
+				"kube_node_status_capacity",
+				"kube_node_status_capacity_pods",
+				"kube_node_status_capacity_memory_bytes",
+				"kube_node_status_capacity_cpu_cores",
+				"kube_node_status_allocatable",
+				"kube_node_status_allocatable_pods",
+				"kube_node_status_allocatable_memory_bytes",
+				"kube_node_status_allocatable_cpu_cores",
+				"kube_node_spec_unschedulable",
+				"kube_node_labels",
+				"kube_node_role",
+				"kube_node_info",
+				"kube_node_created",
+			},
 		},
 		// Verify phase enumerations.
 		{


### PR DESCRIPTION
Backport of #16 for 4.1.

@LiliC @paulfantom @LiliC 