### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/k8s.io/kube-state-metrics
 COPY . .
 ENV GOFLAGS="-mod=vendor"
@@ -8,7 +8,8 @@ FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="kube-state-metrics" \
       io.k8s.description="This is a component that exposes metrics about Kubernetes objects." \
       io.openshift.tags="kubernetes" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"
+      summary="This is a component that exposes metrics about Kubernetes objects." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 ARG FROM_DIRECTORY=/go/src/k8s.io/kube-state-metrics
 COPY --from=builder ${FROM_DIRECTORY}/kube-state-metrics  /usr/bin/kube-state-metrics


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- explicit golang 1.14 usage

/cc @openshift/openshift-team-monitoring