### PR TITLE
Updating kube-state-metrics builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/k8s.io/kube-state-metrics
 COPY . .
 ENV GOFLAGS="-mod=vendor"
 RUN make build-local
 
-FROM  registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="kube-state-metrics" \
       io.k8s.description="This is a component that exposes metrics about Kubernetes objects." \
       io.openshift.tags="kubernetes" \


### PR DESCRIPTION
Updating kube-state-metrics builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/kube-state-metrics.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.