### PR TITLE
MON-1208: Fix unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build-local: clean
 build: clean
 	docker run --rm -v "${PWD}:/go/src/k8s.io/kube-state-metrics" -w /go/src/k8s.io/kube-state-metrics golang:${GO_VERSION} make build-local
 
-test-unit: clean build
+test-unit:
 	GOOS=$(shell uname -s | tr A-Z a-z) GOARCH=$(ARCH) $(TESTENVVAR) go test --race $(FLAGS) $(PKGS)
 
 shellcheck:

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -53,11 +53,11 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 					Generation:        21,
 				},
 				Status: v1beta1.PodDisruptionBudgetStatus{
-					CurrentHealthy:        12,
-					DesiredHealthy:        10,
-					PodDisruptionsAllowed: 2,
-					ExpectedPods:          15,
-					ObservedGeneration:    111,
+					CurrentHealthy:     12,
+					DesiredHealthy:     10,
+					DisruptionsAllowed: 2,
+					ExpectedPods:       15,
+					ObservedGeneration: 111,
 				},
 			},
 			Want: metadata + `
@@ -77,11 +77,11 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 					Generation: 14,
 				},
 				Status: v1beta1.PodDisruptionBudgetStatus{
-					CurrentHealthy:        8,
-					DesiredHealthy:        9,
-					PodDisruptionsAllowed: 0,
-					ExpectedPods:          10,
-					ObservedGeneration:    1111,
+					CurrentHealthy:     8,
+					DesiredHealthy:     9,
+					DisruptionsAllowed: 0,
+					ExpectedPods:       10,
+					ObservedGeneration: 1111,
 				},
 			},
 			Want: metadata + `


### PR DESCRIPTION
In Kubernetes v1.18, PodDisruptionsAllowed was renamed to
DisruptionsAllowed. The change has already been made in upstream
kube-state-metrics but it is part of the v2 release.

Also, to be able to run the test-unit makefile rule in prow, we need to
remove its dependency to the build rule which requires docker installed.
Hence, I cherry-picked this upstream fix: https://github.com/kubernetes/kube-state-metrics/commit/e6e3dbc1c670540b72e66bc17567235a5e9148bd.