### PR TITLE
Bug 2075091: internal/store: fix metrics slice length

### DIFF
--- a/internal/store/pod.go
+++ b/internal/store/pod.go
@@ -127,19 +127,19 @@ func createPodContainerInfoFamilyGenerator() generator.FamilyGenerator {
 		metric.Gauge,
 		"",
 		wrapPodFunc(func(p *v1.Pod) *metric.Family {
-			ms := make([]*metric.Metric, len(p.Status.ContainerStatuses))
+			ms := []*metric.Metric{}
 			labelKeys := []string{"container", "image_spec", "image", "image_id", "container_id"}
 
-			for i, c := range p.Spec.Containers {
+			for _, c := range p.Spec.Containers {
 				for _, cs := range p.Status.ContainerStatuses {
 					if cs.Name != c.Name {
 						continue
 					}
-					ms[i] = &metric.Metric{
+					ms = append(ms, &metric.Metric{
 						LabelKeys:   labelKeys,
 						LabelValues: []string{cs.Name, c.Image, cs.Image, cs.ImageID, cs.ContainerID},
 						Value:       1,
-					}
+					})
 				}
 			}
 			return &metric.Family{


### PR DESCRIPTION
Problem: In https://github.com/kubernetes/kube-state-metrics/pull/1723 a
potential panic in the pod metrics gathering was fixed by working around
a disconnect of `Spec.Containers` and `Status.ContainerStatuses`. The
slice storing the resulting metrics however was still defined based on
the length of the `Status.ContainerStatuses` list.

Solution: Make the slice dynamic and append metrics to it.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>
(cherry picked from commit 85c6b44237ff00251b6107a311d93993f1402477)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**How does this change affect the cardinality of KSM**: *(increases, decreases or does not change cardinality)*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
