### PR TITLE
Bug 2085329: Use v1 PodDisruptionBudget and CronJob resources

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -29,12 +29,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policy "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	vpaautoscaling "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	vpaclientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
@@ -269,7 +268,7 @@ func (b *Builder) buildConfigMapStores() []cache.Store {
 }
 
 func (b *Builder) buildCronJobStores() []cache.Store {
-	return b.buildStoresFunc(cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]), &batchv1beta1.CronJob{}, createCronJobListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(cronJobMetricFamilies(b.allowAnnotationsList["cronjobs"], b.allowLabelsList["cronjobs"]), &batchv1.CronJob{}, createCronJobListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildDaemonSetStores() []cache.Store {
@@ -325,7 +324,7 @@ func (b *Builder) buildPersistentVolumeStores() []cache.Store {
 }
 
 func (b *Builder) buildPodDisruptionBudgetStores() []cache.Store {
-	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies(b.allowAnnotationsList["poddisruptionbudget"], b.allowLabelsList["poddisruptionbudget"]), &policy.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
+	return b.buildStoresFunc(podDisruptionBudgetMetricFamilies(b.allowAnnotationsList["poddisruptionbudgets"], b.allowLabelsList["poddisruptionbudgets"]), &policyv1.PodDisruptionBudget{}, createPodDisruptionBudgetListWatch, b.useAPIServerCache)
 }
 
 func (b *Builder) buildReplicaSetStores() []cache.Store {

--- a/internal/store/cronjob.go
+++ b/internal/store/cronjob.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -48,7 +48,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descCronJobAnnotationsHelp,
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", j.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -66,7 +66,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			descCronJobLabelsHelp,
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", j.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -84,7 +84,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Info about cronjob.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -101,7 +101,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Unix creation timestamp",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 				if !j.CreationTimestamp.IsZero() {
 					ms = append(ms, &metric.Metric{
@@ -121,7 +121,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Active holds pointers to currently running jobs.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -138,7 +138,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Status.LastScheduleTime != nil {
@@ -159,7 +159,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Suspend flag tells the controller to suspend subsequent executions.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.Suspend != nil {
@@ -180,7 +180,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Deadline in seconds for starting the job if it misses scheduled time for any reason.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.StartingDeadlineSeconds != nil {
@@ -202,7 +202,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Next time the cronjob should be scheduled. The time after lastScheduleTime, or after the cron job's creation time if it's never been scheduled. Use this to determine if the job is delayed.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				// If the cron job is suspended, don't track the next scheduled time
@@ -227,7 +227,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Resource version representing a specific version of the cronjob.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				return &metric.Family{
 					Metrics: resourceVersionMetric(j.ObjectMeta.ResourceVersion),
 				}
@@ -238,7 +238,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Successful job history limit tells the controller how many completed jobs should be preserved.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.SuccessfulJobsHistoryLimit != nil {
@@ -259,7 +259,7 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 			"Failed job history limit tells the controller how many failed jobs should be preserved.",
 			metric.Gauge,
 			"",
-			wrapCronJobFunc(func(j *batchv1beta1.CronJob) *metric.Family {
+			wrapCronJobFunc(func(j *batchv1.CronJob) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if j.Spec.FailedJobsHistoryLimit != nil {
@@ -278,9 +278,9 @@ func cronJobMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 	}
 }
 
-func wrapCronJobFunc(f func(*batchv1beta1.CronJob) *metric.Family) func(interface{}) *metric.Family {
+func wrapCronJobFunc(f func(*batchv1.CronJob) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		cronJob := obj.(*batchv1beta1.CronJob)
+		cronJob := obj.(*batchv1.CronJob)
 
 		metricFamily := f(cronJob)
 
@@ -297,11 +297,11 @@ func createCronJobListWatch(kubeClient clientset.Interface, ns string, fieldSele
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1beta1().CronJobs(ns).List(context.TODO(), opts)
+			return kubeClient.BatchV1().CronJobs(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.BatchV1beta1().CronJobs(ns).Watch(context.TODO(), opts)
+			return kubeClient.BatchV1().CronJobs(ns).Watch(context.TODO(), opts)
 		},
 	}
 }

--- a/internal/store/cronjob_test.go
+++ b/internal/store/cronjob_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -106,7 +106,7 @@ func TestCronJobStore(t *testing.T) {
 			AllowAnnotationsList: []string{
 				"app.k8s.io/owner",
 			},
-			Obj: &batchv1beta1.CronJob{
+			Obj: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "ActiveRunningCronJob1",
 					Namespace:       "ns1",
@@ -120,11 +120,11 @@ func TestCronJobStore(t *testing.T) {
 						"app.k8s.io/owner": "@foo",
 					},
 				},
-				Status: batchv1beta1.CronJobStatus{
+				Status: batchv1.CronJobStatus{
 					Active:           []v1.ObjectReference{{Name: "FakeJob1"}, {Name: "FakeJob2"}},
 					LastScheduleTime: &metav1.Time{Time: ActiveRunningCronJob1LastScheduleTime},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
 					ConcurrencyPolicy:          "Forbid",
 					Suspend:                    &SuspendFalse,
@@ -186,7 +186,7 @@ func TestCronJobStore(t *testing.T) {
 			},
 		},
 		{
-			Obj: &batchv1beta1.CronJob{
+			Obj: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "SuspendedCronJob1",
 					Namespace:       "ns1",
@@ -196,11 +196,11 @@ func TestCronJobStore(t *testing.T) {
 						"app": "example-suspended-1",
 					},
 				},
-				Status: batchv1beta1.CronJobStatus{
+				Status: batchv1.CronJobStatus{
 					Active:           []v1.ObjectReference{},
 					LastScheduleTime: &metav1.Time{Time: SuspendedCronJob1LastScheduleTime},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
 					ConcurrencyPolicy:          "Forbid",
 					Suspend:                    &SuspendTrue,
@@ -243,7 +243,7 @@ func TestCronJobStore(t *testing.T) {
 			MetricNames: []string{"kube_cronjob_spec_starting_deadline_seconds", "kube_cronjob_status_active", "kube_cronjob_metadata_resource_version", "kube_cronjob_spec_suspend", "kube_cronjob_info", "kube_cronjob_created", "kube_cronjob_labels", "kube_cronjob_status_last_schedule_time", "kube_cronjob_spec_successful_job_history_limit", "kube_cronjob_spec_failed_job_history_limit"},
 		},
 		{
-			Obj: &batchv1beta1.CronJob{
+			Obj: &batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "ActiveCronJob1NoLastScheduled",
 					CreationTimestamp: metav1.Time{Time: ActiveCronJob1NoLastScheduledCreationTimestamp},
@@ -254,11 +254,11 @@ func TestCronJobStore(t *testing.T) {
 						"app": "example-active-no-last-scheduled-1",
 					},
 				},
-				Status: batchv1beta1.CronJobStatus{
+				Status: batchv1.CronJobStatus{
 					Active:           []v1.ObjectReference{},
 					LastScheduleTime: nil,
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					StartingDeadlineSeconds:    &StartingDeadlineSeconds300,
 					ConcurrencyPolicy:          "Forbid",
 					Suspend:                    &SuspendFalse,

--- a/internal/store/poddisruptionbudget.go
+++ b/internal/store/poddisruptionbudget.go
@@ -19,7 +19,7 @@ package store
 import (
 	"context"
 
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -45,7 +45,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			descPodDisruptionBudgetAnnotationsHelp,
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				annotationKeys, annotationValues := createPrometheusLabelKeysValues("annotation", p.Annotations, allowAnnotationsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -63,7 +63,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			descPodDisruptionBudgetLabelsHelp,
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
 				return &metric.Family{
 					Metrics: []*metric.Metric{
@@ -81,7 +81,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Unix creation timestamp",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				ms := []*metric.Metric{}
 
 				if !p.CreationTimestamp.IsZero() {
@@ -100,7 +100,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Current number of healthy pods",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -115,7 +115,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Minimum desired number of healthy pods",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -130,7 +130,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Number of pod disruptions that are currently allowed",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -145,7 +145,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Total number of pods counted by this disruption budget",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -160,7 +160,7 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 			"Most recent generation observed when updating this PDB status",
 			metric.Gauge,
 			"",
-			wrapPodDisruptionBudgetFunc(func(p *v1beta1.PodDisruptionBudget) *metric.Family {
+			wrapPodDisruptionBudgetFunc(func(p *policyv1.PodDisruptionBudget) *metric.Family {
 				return &metric.Family{
 					Metrics: []*metric.Metric{
 						{
@@ -173,9 +173,9 @@ func podDisruptionBudgetMetricFamilies(allowAnnotationsList, allowLabelsList []s
 	}
 }
 
-func wrapPodDisruptionBudgetFunc(f func(*v1beta1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
+func wrapPodDisruptionBudgetFunc(f func(*policyv1.PodDisruptionBudget) *metric.Family) func(interface{}) *metric.Family {
 	return func(obj interface{}) *metric.Family {
-		podDisruptionBudget := obj.(*v1beta1.PodDisruptionBudget)
+		podDisruptionBudget := obj.(*policyv1.PodDisruptionBudget)
 
 		metricFamily := f(podDisruptionBudget)
 
@@ -192,11 +192,11 @@ func createPodDisruptionBudgetListWatch(kubeClient clientset.Interface, ns strin
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).List(context.TODO(), opts)
+			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return kubeClient.PolicyV1beta1().PodDisruptionBudgets(ns).Watch(context.TODO(), opts)
+			return kubeClient.PolicyV1().PodDisruptionBudgets(ns).Watch(context.TODO(), opts)
 		},
 	}
 }

--- a/internal/store/poddisruptionbudget_test.go
+++ b/internal/store/poddisruptionbudget_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
@@ -51,14 +51,14 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 	`
 	cases := []generateMetricsTestCase{
 		{
-			Obj: &v1beta1.PodDisruptionBudget{
+			Obj: &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "pdb1",
 					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
 					Namespace:         "ns1",
 					Generation:        21,
 				},
-				Status: v1beta1.PodDisruptionBudgetStatus{
+				Status: policyv1.PodDisruptionBudgetStatus{
 					CurrentHealthy:     12,
 					DesiredHealthy:     10,
 					DisruptionsAllowed: 2,
@@ -78,13 +78,13 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 			`,
 		},
 		{
-			Obj: &v1beta1.PodDisruptionBudget{
+			Obj: &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "pdb2",
 					Namespace:  "ns2",
 					Generation: 14,
 				},
-				Status: v1beta1.PodDisruptionBudgetStatus{
+				Status: policyv1.PodDisruptionBudgetStatus{
 					CurrentHealthy:     8,
 					DesiredHealthy:     9,
 					DisruptionsAllowed: 0,
@@ -109,7 +109,7 @@ func TestPodDisruptionBudgetStore(t *testing.T) {
 			AllowLabelsList: []string{
 				"app",
 			},
-			Obj: &v1beta1.PodDisruptionBudget{
+			Obj: &policyv1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pdb_with_allowed_labels_and_annotations",
 					Namespace: "ns",

--- a/tests/manifests/cronjob.yaml
+++ b/tests/manifests/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cronjob

--- a/tests/manifests/poddisruptionbudget.yaml
+++ b/tests/manifests/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pdb


### PR DESCRIPTION
Both the PodDisruptionBudget and CronJob resources have been promoted
to v1 as of Kubernetes v1.21 release.  The previous v1beta1 versions
are now deprecated, and will be removed in v1.25 and above.  This
updates all references to the new v1 versions.

(cherry picked from commit d01ad03ae64661f37caa79b97ad8a4edf2ac3933)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:  kube-state-metrics trips APIRemovedInNextEUSReleaseInUse in 4.10 clusters because it is watching v1beta PDB

**How does this change affect the cardinality of KSM**: *does not change cardinality*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2085326
