### PR TITLE
OCPBUGS-4089: cherry-pick, do not expose ingress path metric when service is nil

### DIFF
--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -141,11 +141,13 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 				for _, rule := range i.Spec.Rules {
 					if rule.HTTP != nil {
 						for _, path := range rule.HTTP.Paths {
-							ms = append(ms, &metric.Metric{
-								LabelKeys:   []string{"host", "path", "service_name", "service_port"},
-								LabelValues: []string{rule.Host, path.Path, path.Backend.Service.Name, strconv.Itoa(int(path.Backend.Service.Port.Number))},
-								Value:       1,
-							})
+							if path.Backend.Service != nil {
+								ms = append(ms, &metric.Metric{
+									LabelKeys:   []string{"host", "path", "service_name", "service_port"},
+									LabelValues: []string{rule.Host, path.Path, path.Backend.Service.Name, strconv.Itoa(int(path.Backend.Service.Port.Number))},
+									Value:       1,
+								})
+							}
 						}
 					}
 				}

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -150,7 +150,7 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 							} else {
 								ms = append(ms, &metric.Metric{
 									LabelKeys:   []string{"host", "path", "service_name", "service_port"},
-									LabelValues: []string{rule.Host, path.Path, "<none>", "<none>"},
+									LabelValues: []string{rule.Host, path.Path, "", ""},
 									Value:       1,
 								})
 							}

--- a/internal/store/ingress.go
+++ b/internal/store/ingress.go
@@ -147,6 +147,12 @@ func ingressMetricFamilies(allowAnnotationsList, allowLabelsList []string) []gen
 									LabelValues: []string{rule.Host, path.Path, path.Backend.Service.Name, strconv.Itoa(int(path.Backend.Service.Port.Number))},
 									Value:       1,
 								})
+							} else {
+								ms = append(ms, &metric.Metric{
+									LabelKeys:   []string{"host", "path", "service_name", "service_port"},
+									LabelValues: []string{rule.Host, path.Path, "<none>", "<none>"},
+									Value:       1,
+								})
 							}
 						}
 					}

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -19,6 +19,7 @@ package store
 import (
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -144,6 +145,15 @@ func TestIngressStore(t *testing.T) {
 												},
 											},
 										},
+										{
+											Path: "/somepath2",
+											Backend: networkingv1.IngressBackend{
+												Resource: &v1.TypedLocalObjectReference{
+													Kind: "somekind",
+													Name: "somename",
+												},
+											},
+										},
 									},
 								},
 							},
@@ -159,6 +169,7 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_created{namespace="ns4",ingress="ingress4"} 1.501569018e+09
 				kube_ingress_labels{namespace="ns4",ingress="ingress4"} 1
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath",service_name="someservice",service_port="1234"} 1
+				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath2",service_name="<none>",service_port="<none>"} 1
 `,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},

--- a/internal/store/ingress_test.go
+++ b/internal/store/ingress_test.go
@@ -169,7 +169,7 @@ func TestIngressStore(t *testing.T) {
 				kube_ingress_created{namespace="ns4",ingress="ingress4"} 1.501569018e+09
 				kube_ingress_labels{namespace="ns4",ingress="ingress4"} 1
 				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath",service_name="someservice",service_port="1234"} 1
-				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath2",service_name="<none>",service_port="<none>"} 1
+				kube_ingress_path{namespace="ns4",ingress="ingress4",host="somehost",path="/somepath2",service_name="",service_port=""} 1
 `,
 			MetricNames: []string{"kube_ingress_info", "kube_ingress_metadata_resource_version", "kube_ingress_created", "kube_ingress_labels", "kube_ingress_path", "kube_ingress_tls"},
 		},


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCPBUGS-4086

Upstream PR: https://github.com/kubernetes/kube-state-metrics/pull/1841

Problem: when in an Ingress Path.Backend.Service is nil kube-state-metrics will crash with a nil pointer

Solution: Validate if Path.Backend.Service is set