### PR TITLE
Revert "OCPBUGS-34202: Updating kube-state-metrics-container image to be consistent with ART for 4.17"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.21-openshift-4.17

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
 WORKDIR /go/src/k8s.io/kube-state-metrics
 COPY . .
 ENV GOFLAGS="-mod=vendor"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-state-metrics/v2
 
-go 1.22
+go 1.21
 
 require (
 	github.com/dgryski/go-jump v0.0.0-20211018200510-ba001c3ffce0


### PR DESCRIPTION
Reverts openshift/kube-state-metrics#113

This is just a test we have no intention of merging, we're trying to find what PR fixes a suspected performance problem in kubelet metrics, and this PR is in the payload where our problem disappeared.

/hold