### PR TITLE
[DO NOT MERGE] Testing `skos` job before v2.16 merge

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,14 +26,18 @@ import (
 
 func main() {
 	opts := options.NewOptions()
+
 	cmd := options.InitCommand
 	cmd.Run = func(_ *cobra.Command, _ []string) {
 		internal.RunKubeStateMetricsWrapper(opts)
 	}
+
 	opts.AddFlags(cmd)
+
 	if err := opts.Parse(); err != nil {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
+
 	if err := opts.Validate(); err != nil {
 		klog.ErrorS(err, "Validating options error")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)


### PR DESCRIPTION
This is an ~empty~ commit to double-verify that the `skos` job, albeit not a required one, isn't flaking owing to the v2.16 changes (the job history in Prow isn't adequate to make a decision).

See: https://github.com/openshift/kube-state-metrics/pull/122