### PR TITLE
OCPBUGS-74874: Deduplicate CRS stores

### DIFF
--- a/internal/store/builder.go
+++ b/internal/store/builder.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -113,12 +113,10 @@ func (b *Builder) WithEnabledResources(r []string) error {
 		}
 	}
 
-	var sortedResources []string
-	sortedResources = append(sortedResources, r...)
+	b.enabledResources = append(b.enabledResources, r...)
+	slices.Sort(b.enabledResources)
+	b.enabledResources = slices.Compact(b.enabledResources)
 
-	sort.Strings(sortedResources)
-
-	b.enabledResources = append(b.enabledResources, sortedResources...)
 	return nil
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/kube-state-metrics/pull/2502 deduplicated custom resource metric stores, and landed in KSM v2.15, first shipped in OCP v4.19.

https://github.com/rexagod/kube-state-metrics/commit/6f04c6100e4c730ae8ba923676658b95de7d1cd1 demonstrates the reproduced issue, and fails the test, as expected, due to multiple metrics being piped out. Whereas, https://github.com/rexagod/kube-state-metrics/commit/119bf08ec9c15c93e9e36b4b702ef0e62ea41666 passes the test, since the fix is currently present in [OCP 4.19+](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.19.0-rc.0).