### PR TITLE
OCPBUGS-86653: [Backport] Handle DeletedFinalStateUnknown panic

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -49,7 +49,15 @@ func (r *CRDiscoverer) StartDiscovery(ctx context.Context, config *rest.Config) 
 	informer := factory.Informer()
 	stopper := make(chan struct{})
 	extractGVKPs := func(obj interface{}) []groupVersionKindPlural {
-		objSpec := obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
+		if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			obj = d.Obj
+		}
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			klog.ErrorS(nil, "expected *unstructured.Unstructured", "got", fmt.Sprintf("%T", obj))
+			return nil
+		}
+		objSpec := u.Object["spec"].(map[string]interface{})
 		var gvkps []groupVersionKindPlural
 		for _, version := range objSpec["versions"].([]interface{}) {
 			g := objSpec["group"].(string)

--- a/pkg/customresourcestate/registry_factory.go
+++ b/pkg/customresourcestate/registry_factory.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kube-state-metrics/v2/internal/store"
@@ -672,7 +673,15 @@ func famGen(f compiledFamily) generator.FamilyGenerator {
 		Type: f.Each.Type(),
 		Help: f.Help,
 		GenerateFunc: func(obj interface{}) *metric.Family {
-			return generate(obj.(*unstructured.Unstructured), f, errLog)
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				klog.ErrorS(nil, "expected *unstructured.Unstructured", "got", fmt.Sprintf("%T", obj))
+				return &metric.Family{}
+			}
+			return generate(u, f, errLog)
 		},
 	}
 }


### PR DESCRIPTION
This is a backport of https://github.com/kubernetes/kube-state-metrics/commit/4472b1f1cc8ad165e649aac92ebbc6a8a508613b for the `release-4.22` branch.

***

kube-state-metrics panics with a type assertion failure when processing deleted objects from the client-go informer cache. The informer wraps deleted objects in `cache.DeletedFinalStateUnknown`, but the code directly type-asserts to `*unstructured.Unstructured` without unwrapping first.

/cherry-pick release-4.21
/cherry-pick release-4.20